### PR TITLE
test with a small file http download

### DIFF
--- a/app/processors/concerns/http_files.rb
+++ b/app/processors/concerns/http_files.rb
@@ -19,13 +19,13 @@ module HttpFiles
 
     prior_remaining, prior_total = 0
     streamer = lambda do |chunk, remaining_bytes, total_bytes|
-      if (remaining_bytes > prior_remaining) || (total_bytes != prior_total) || !temp_file
+      if (remaining_bytes.to_i > prior_remaining) || (total_bytes.to_i != prior_total) || !temp_file
         close_temp_file(temp_file)
         temp_file = AudioMonster.create_temp_file(uri.to_s)
       end
 
-      prior_remaining = remaining_bytes
-      prior_total = total_bytes
+      prior_remaining = remaining_bytes.to_i
+      prior_total = total_bytes.to_i
       temp_file.write(chunk)
     end
 
@@ -53,7 +53,7 @@ module HttpFiles
 
     raise "HTTP Download #{uri}: did not complete" unless file_downloaded
 
-    raise "HTTP Download #{uri}: #{temp_file.size} is not the expected size: #{prior_total}" if temp_file.size != prior_total
+    raise "HTTP Download #{uri}: #{temp_file.size} is not the expected size: #{prior_total}" if prior_total > 0 && temp_file.size != prior_total
 
     raise "HTTP Download #{uri}: Zero length file downloaded" if temp_file.size == 0
 

--- a/test/processors/concerns/http_files_test.rb
+++ b/test/processors/concerns/http_files_test.rb
@@ -23,6 +23,7 @@ class HttpFilesTest < ActiveSupport::TestCase
 
   let(:http_uri) { URI.parse('http://test.prx.org/test/file.mp2') }
   let(:https_uri) { URI.parse('https://test.prx.org/test/file.mp2') }
+  let(:small_uri) { URI.parse('http://test.prx.org/test/small.txt') }
 
   it 'can download from http url' do
 
@@ -31,6 +32,15 @@ class HttpFilesTest < ActiveSupport::TestCase
       to_return(status: 200, headers: {}, body: File.open(in_file('test_short.mp2')))
 
     tmp = processor.http_download_file(http_uri)
+    tmp.must_be_instance_of File
+  end
+
+  it 'can download a small file' do
+    stub_request(:get, small_uri.to_s).
+      with(headers: { 'Host' => 'test.prx.org:80' } ).
+      to_return(status: 200, headers: {}, body: "so very small")
+
+    tmp = processor.http_download_file(small_uri)
     tmp.must_be_instance_of File
   end
 


### PR DESCRIPTION
this is a different approach to #30 where the validation for the final file size is ignored in the case where there was no total size provided by excon.

it also uses to_i on excon values to ensure they are not nil and invalid for comparisons.