### PR TITLE
Fix say_when foreign key type

### DIFF
--- a/app/models/base_model.rb
+++ b/app/models/base_model.rb
@@ -14,9 +14,7 @@ class BaseModel < ActiveRecord::Base
   def retry_scheduled?
     scheduled_jobs.
       where(job_method: 'scheduled_retry').
-      where('next_fire_at > ?', Time.now).
-      where('status != \'complete\'').exists?
-  rescue
-    false
+      where('status != ?', COMPLETE).
+      exists?
   end
 end

--- a/db/migrate/20150615205022_change_say_when_fk_type.rb
+++ b/db/migrate/20150615205022_change_say_when_fk_type.rb
@@ -1,0 +1,10 @@
+class ChangeSayWhenFkType < ActiveRecord::Migration
+  def change
+    reversible do |dir|
+      change_table :say_when_jobs do |t|
+        dir.up   { t.change :scheduled_id, :string }
+        dir.down { t.change :scheduled_id, :integer }
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150611174830) do
+ActiveRecord::Schema.define(version: 20150615205022) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -100,7 +100,7 @@ ActiveRecord::Schema.define(version: 20150611174830) do
     t.string   "job_method"
     t.text     "data"
     t.string   "scheduled_type"
-    t.integer  "scheduled_id"
+    t.string   "scheduled_id"
     t.datetime "created_at",       null: false
     t.datetime "updated_at",       null: false
   end

--- a/test/models/job_test.rb
+++ b/test/models/job_test.rb
@@ -64,6 +64,21 @@ class JobTest < ActiveSupport::TestCase
     job.calculate_retry_delay.must_equal 7.days
   end
 
+  it 'can have retries scheduled' do
+    # set-up preconditions to retry
+    t1 = job.tasks.create!(task_type: 'audio', label: 'test1')
+    job.retry_max = 10
+
+    job.wont_be :success?
+    job.wont_be :cancelled?
+    job.must_be :retry?
+    job.wont_be :retry_scheduled?
+
+    job.retry_on_error
+
+    job.must_be :retry_scheduled?
+  end
+
   describe 'task updates' do
 
     let(:task) { job.tasks.create!(task_type: 'audio', label: 'test1')}


### PR DESCRIPTION
Need to be able to link to scheduled models with uuid primary key.